### PR TITLE
Add the option to choose months' names for the hijri calendar

### DIFF
--- a/docs/ArDateTime.md
+++ b/docs/ArDateTime.md
@@ -59,3 +59,38 @@ echo $arD->arToDayDateTimeString();
 //  'الجمعة, شوال 19, 1438 8:21 مساءً'
 ```
 
+### Set the output of the date format:
+```
+$arD = ArUtil::date()->arCreate(1438, 10, 19, 2, 15, 30);
+
+echo $arD->arFormat('l dS F Y h:i:s A');
+ // 'الجمعة 19 شوال 1438 02:21:39 صباحاً' 
+
+$arD->setOutputMode(ArDateTime::ALGERIA_AND_TUNIS);
+echo $arD->arFormat('l dS F Y h:i:s A');
+ // 'الجمعة 14 جويلية 2017 02:15:30 صباحاً' 
+ 
+$arD->setOutputMode(ArDateTime::ARABIC_AND_TRANSLITERATION);
+echo $arD->arFormat('l dS F Y h:i:s A');
+ // 'الجمعة 14 تموز/يوليو 2017 02:15:30 صباحاً' 
+ 
+$arD->setOutputMode(ArDateTime::ARABIC_MONTH_NAMES);
+echo $arD->arFormat('l dS F Y h:i:s A');
+ // 'الجمعة 14 تموز 2017 02:15:30 صباحاً' 
+ 
+$arD->setOutputMode(ArDateTime::HIJRI_FORMAT_IN_ENGLISH);
+echo $arD->arFormat('l dS F Y h:i:s A');
+ // 'Friday 19 Shawwal 1438 02:15:30 AM' 
+ 
+$arD->setOutputMode(ArDateTime::MOROCCO_STYLE);
+echo $arD->arFormat('l dS F Y h:i:s A');
+// 'الجمعة 14 يوليوز 2017 02:15:30 صباحاً'
+
+$arD->setOutputMode(ArDateTime::LIBYA_STYLE);
+echo $arD->arFormat('l dS F Y h:i:s A');
+// 'الجمعة 14 ناصر 1385 02:15:30 صباحاً'
+
+$arD->setOutputMode(ArDateTime::ARABIC_TRANSLITERATION);
+echo $arD->arFormat('l dS F Y h:i:s A');
+// 'الجمعة 14 يوليو 2017 02:15:30 صباحاً'
+```

--- a/src/ArUtil/Time/ArDateTime.php
+++ b/src/ArUtil/Time/ArDateTime.php
@@ -202,6 +202,23 @@ class ArDateTime extends Carbon
 	}
 	
 	/**
+	 * Update the hijri date when the timestamp changes
+	 * @param int $timestamp
+	 *
+	 * @return static
+	 */
+	public function setTimestamp( $timestamp ) {
+		$instance = parent::setTimestamp( $timestamp );
+		list(
+			$instance->arYear,
+			$instance->arMonth,
+			$instance->arDay
+			) = ( new Date() )->hjConvert( $instance->year, $instance->month, $instance->day );
+		
+		return $instance;
+	}
+	
+	/**
      * Set the instance Hijri date for today.
      */
     private function setTodayHijriDate()

--- a/src/ArUtil/Time/ArDateTime.php
+++ b/src/ArUtil/Time/ArDateTime.php
@@ -235,7 +235,7 @@ class ArDateTime extends Carbon
 	 *
 	 * @return ArDateTime
 	 */
-	public function setOutputMode( int $outputMode ) {
+	public function setOutputMode( $outputMode ) {
 		$this->outputMode = $outputMode;
 		
 		return $this;

--- a/src/ArUtil/Time/ArDateTime.php
+++ b/src/ArUtil/Time/ArDateTime.php
@@ -183,8 +183,25 @@ class ArDateTime extends Carbon
     {
         return $this->arFormat('Y-m-d');
     }
-    
-    /**
+	
+	/**
+	 * Update the hijri date when the instance timestamp is changed
+	 * @param string $modify
+	 *
+	 * @return static
+	 */
+	public function modify( $modify ) {
+		$instance = parent::modify( $modify );
+		list(
+			$instance->arYear,
+			$instance->arMonth,
+			$instance->arDay
+			) = ( new Date() )->hjConvert( $instance->year, $instance->month, $instance->day );
+		
+		return $instance;
+	}
+	
+	/**
      * Set the instance Hijri date for today.
      */
     private function setTodayHijriDate()

--- a/src/ArUtil/Time/ArDateTime.php
+++ b/src/ArUtil/Time/ArDateTime.php
@@ -14,11 +14,22 @@ use InvalidArgumentException;
  */
 class ArDateTime extends Carbon
 {
-    
-    /**
+	
+	const HIJRI_FORMAT = 1;
+	const ARABIC_MONTH_NAMES = 2;
+	const ARABIC_TRANSLITERATION = 3;
+	const ARABIC_AND_TRANSLITERATION = 4;
+	const LIBYA_STYLE = 5;
+	const ALGERIA_AND_TUNIS = 6;
+	const MOROCCO_STYLE = 7;
+	const HIJRI_FORMAT_IN_ENGLISH = 8;
+	
+	/**
      * @var boolean The instance date is modified.
      */
     private $isDirty;
+    
+    private $outputMode = self::HIJRI_FORMAT;
     
     /**
      * Create new instance of ArDateTime and set the hijri date to the date provided.
@@ -165,7 +176,7 @@ class ArDateTime extends Carbon
     public function arFormat($format)
     {
         $d = new Date();
-        
+	    $d->setMode($this->outputMode);
         return $d->date($format, $this->timestamp);
     }
     
@@ -216,6 +227,18 @@ class ArDateTime extends Carbon
 			) = ( new Date() )->hjConvert( $instance->year, $instance->month, $instance->day );
 		
 		return $instance;
+	}
+	
+	/**
+	 * Set the output mode from the arFormat method
+	 * @param int $outputMode
+	 *
+	 * @return ArDateTime
+	 */
+	public function setOutputMode( int $outputMode ) {
+		$this->outputMode = $outputMode;
+		
+		return $this;
 	}
 	
 	/**

--- a/tests/Time/StringsTest.php
+++ b/tests/Time/StringsTest.php
@@ -12,6 +12,7 @@
 namespace ArUtil\Tests\Time;
 
 use ArUtil\ArUtil;
+use ArUtil\Time\ArDateTime;
 
 class StringsTest extends AbstractTimeTest
 {
@@ -30,6 +31,34 @@ class StringsTest extends AbstractTimeTest
     {
         $arD = ArUtil::date()->arCreate(1438, 10, 19);
         $this->assertEquals(19, $arD->arFormat('j'));
+    }
+    
+    /** @test */
+    public function it_rerun_hijri_according_to_outpu_mode()
+    {
+        $arD = ArUtil::date()->arCreate(1438, 10, 19, 2, 15, 30);
+        
+        $arD->setOutputMode(ArDateTime::ALGERIA_AND_TUNIS);
+        $this->assertEquals('الجمعة 14 جويلية 2017 02:15:30 صباحاً', $arD->arFormat('l dS F Y h:i:s A'));
+        
+        $arD->setOutputMode(ArDateTime::ARABIC_AND_TRANSLITERATION);
+        $this->assertEquals('الجمعة 14 تموز/يوليو 2017 02:15:30 صباحاً', $arD->arFormat('l dS F Y h:i:s A'));
+        
+        $arD->setOutputMode(ArDateTime::ARABIC_MONTH_NAMES);
+        $this->assertEquals('الجمعة 14 تموز 2017 02:15:30 صباحاً', $arD->arFormat('l dS F Y h:i:s A'));
+        
+        $arD->setOutputMode(ArDateTime::HIJRI_FORMAT_IN_ENGLISH);
+        $this->assertEquals('Friday 19 Shawwal 1438 02:15:30 AM', $arD->arFormat('l dS F Y h:i:s A'));
+        
+        $arD->setOutputMode(ArDateTime::LIBYA_STYLE);
+        $this->assertEquals('الجمعة 14 ناصر 1385 02:15:30 صباحاً', $arD->arFormat('l dS F Y h:i:s A'));
+        
+        $arD->setOutputMode(ArDateTime::MOROCCO_STYLE);
+        $this->assertEquals('الجمعة 14 يوليوز 2017 02:15:30 صباحاً', $arD->arFormat('l dS F Y h:i:s A'));
+        
+        $arD->setOutputMode(ArDateTime::ARABIC_TRANSLITERATION);
+        $this->assertEquals('الجمعة 14 يوليو 2017 02:15:30 صباحاً', $arD->arFormat('l dS F Y h:i:s A'));
+        
     }
     
     /** @test */

--- a/tests/Time/UpdateHijriDateTest.php
+++ b/tests/Time/UpdateHijriDateTest.php
@@ -19,4 +19,15 @@ class UpdateHijriDateTest extends AbstractTimeTest
 
 	    $this->assertArDateTime($arD, 1438, 10, 25);
     }
+    
+    /** @test */
+    public function it_updates_its_hijri_date_when_timestamp_is_updated()
+    {
+        $arD = ArUtil::date()->arCreateFromDate(1438, 10, 15);
+        $this->assertCarbon($arD, 2017, 7, 10);
+
+        $arD->timestamp(1498822449); // - 10 Days
+
+	    $this->assertArDateTime($arD, 1438, 10, 5);
+    }
 }

--- a/tests/Time/UpdateHijriDateTest.php
+++ b/tests/Time/UpdateHijriDateTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ArUtil\Tests\Time;
+
+use ArUtil\ArUtil;
+use ArUtil\Time\ArDateTime;
+use Carbon\Carbon;
+
+class UpdateHijriDateTest extends AbstractTimeTest
+{
+    
+    /** @test */
+    public function it_updates_its_hijri_date_when_carbon_dates_changes()
+    {
+        $arD = ArUtil::date()->arCreateFromDate(1438, 10, 15);
+        $this->assertCarbon($arD, 2017, 7, 10);
+        
+        $arD->addDays(10);
+
+	    $this->assertArDateTime($arD, 1438, 10, 25);
+    }
+}


### PR DESCRIPTION
You can add one of these constants to choose how the is the format of the date output.
```php
	const HIJRI_FORMAT = 1;
	const ARABIC_MONTH_NAMES = 2;
	const ARABIC_TRANSLITERATION = 3;
	const ARABIC_AND_TRANSLITERATION = 4;
	const LIBYA_STYLE = 5;
	const ALGERIA_AND_TUNIS = 6;
	const MOROCCO_STYLE = 7;
	const HIJRI_FORMAT_IN_ENGLISH = 8;

```

These can be applied by calling `$arD->setOutputMode(ArDateTime::HIJRI_FORMAT_IN_ENGLISH);`
